### PR TITLE
Documented: Model index, Fixed: main readme examples, Changed: action-prohibited

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Listing the installed models.
 
 ### create
 
-Notice: The user object is not the toplevel object in the request.
-
-**NOTE:** Content-Type is important!
+**NOTES:**
+Content-Type is important!
+The user object is not the toplevel object in the request.
 
 ```
 > curl -k -H "Content-Type: application/json" -X POST \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Listing the installed models.
 
 Notice: The user object is not the toplevel object in the request.
 
+**NOTE:** Content-Type is important!
+
 ```
 > curl -k -H "Content-Type: application/json" -X POST \
 > https://localhost:8000/users --data @- <<EOF 
@@ -130,6 +132,8 @@ Notice: The user object is not the toplevel object in the request.
 ### update
 
 Promote Max Mustermann as admin.
+
+**NOTE:** Content-Type is important!
 
 ```
 > curl -k -H "Content-Type: application/json" -X PUT \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Listing the installed models.
 > curl -k https://locahost:8000/_discover
 {
   "models": [
-    "user"
+    "users"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Listing the installed models.
 ### create
 
 **NOTES:**
-Content-Type is important!
-The user object is not the toplevel object in the request.
+* Content-Type is important!
+* The user object is not the toplevel object in the request.
 
 ```
 > curl -k -H "Content-Type: application/json" -X POST \

--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ Promote Max Mustermann as admin.
 > https://localhost:8000/users/55f2e87276418f4d3c64d56e --data @- <<EOF
 > {
 >   "users": {
->     "name": "Max Mustermann",
->     "email": "max@mustermann.tld",
 >     "admin": true
 >   }
 > }

--- a/modules/models/README.md
+++ b/modules/models/README.md
@@ -31,3 +31,35 @@ Requires ```model:*```: Object defining model:
   idGenerator: Function                       // ID generator function (optional)
 }
 ```
+
+### Index Examples
+
+**Simple:**
+``` javascript
+...
+index: [ 'email' ]
+...
+```
+
+**With Options:**
+``` javascript
+...
+index: [ [ 'email', { unique: true } ] ]
+...
+```
+
+**Compound:**
+``` javascript
+...
+index: [ [ ['prename', 'surname'], { unique: true } ] ]
+...
+```
+
+**More than one index:**
+``` javascript
+...
+index: [ [ ['prename', 'surname'], { unique: true } ], [ 'email', { unique: true } ], 'phone' ]
+...
+```
+
+

--- a/modules/models/README.md
+++ b/modules/models/README.md
@@ -34,6 +34,8 @@ Requires ```model:*```: Object defining model:
 
 ### Index Examples
 
+**NOTE:** Since *JMF* calls the ``` ensureIndex( ... )``` function of the mongodb driver, it's only ensured that the index is existing. If you modify the index, you have to remove the index **manually** in mongo and the next time *JMF* is started the index is built correctly.
+
 **Simple:**
 ``` javascript
 ...

--- a/modules/models/app-errhandlers.js
+++ b/modules/models/app-errhandlers.js
@@ -27,6 +27,10 @@ module.exports.factory = function( ModelsError ) { return {
 				case 'drop-fail':
 					code = 500; // Internal Server Error
 					break;
+                                case 'action-prohibited':
+                                        // TODO: rfc2616 - 14.7 Allow
+                                        code = 405;
+                                        break;
 				default:
 					code = 400;
 			}


### PR DESCRIPTION
I wrote some documentation and changed the http status code of ```'action-prohibited'``` to 405. According to ```rfc2616 - 14.7 Allow``` the allowed http methods have to be returned in the http response. Because I have no idea atm. how to implement this in a good way, I simply left a TODO notice. ;-)

Fixes: #2 